### PR TITLE
Extra params

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # A Node.js OAuth Agent for SPAs
 
-[![Quality](https://img.shields.io/badge/quality-experiment-red)](https://curity.io/resources/code-examples/status/)
+[![Quality](https://img.shields.io/badge/quality-test-yellow)](https://curity.io/resources/code-examples/status/)
 [![Availability](https://img.shields.io/badge/availability-source-blue)](https://curity.io/resources/code-examples/status/)
 
 ## Overview

--- a/doc/Architecture.md
+++ b/doc/Architecture.md
@@ -32,6 +32,24 @@ Response:
 }
 ```
 
+If required, the SPA can POST an object with an extra params field containing runtime OpenID Connect parameters.\
+They key and value of each item must be strings and they will then be appended to the request URL.
+
+```json
+{
+  "extraParams": [
+      {
+          "key": "max-age",
+          "value": "3600",
+      },
+      {
+          "key": "ui_locales",
+          "value": "fr",
+      },
+  ]
+}
+```
+
 ### POST `/login/end`
 
 This endpoint should be be called by the SPA on any page load. The SPA sends the current URL to the API, which can either finish the authorization flow (if it was a response from the Authorization Server), or inform the SPA whether the user is logged in or not (based on the presence of secure cookies).

--- a/src/controller/LoginController.ts
+++ b/src/controller/LoginController.ts
@@ -47,7 +47,7 @@ class LoginController {
         options.requireCsrfHeader = false;
         validateExpressRequest(req, options)
 
-        const authorizationRequestData = getAuthorizationURL(config)
+        const authorizationRequestData = getAuthorizationURL(config, req.body)
 
         res.setHeader('Set-Cookie',
             getTempLoginDataCookie(authorizationRequestData.codeVerifier, authorizationRequestData.state, config.cookieOptions, config.cookieNamePrefix, config.encKey))

--- a/src/lib/authorizationURL.ts
+++ b/src/lib/authorizationURL.ts
@@ -14,10 +14,11 @@
  *  limitations under the License.
  */
 
+import {LoginOptions} from './loginOptions'
 import OAuthAgentConfiguration from './oauthAgentConfiguration'
 import {generateHash, generateRandomString} from './pkce'
 
-function getAuthorizationURL(config: OAuthAgentConfiguration): AuthorizationRequestData {
+function getAuthorizationURL(config: OAuthAgentConfiguration, options?: LoginOptions): AuthorizationRequestData {
     const codeVerifier = generateRandomString()
     const state = generateRandomString()
 
@@ -28,6 +29,14 @@ function getAuthorizationURL(config: OAuthAgentConfiguration): AuthorizationRequ
         "&redirect_uri=" + encodeURIComponent(config.redirectUri) +
         "&code_challenge=" + generateHash(codeVerifier) +
         "&code_challenge_method=S256"
+
+    if (options && options.extraParams) {
+        options.extraParams.forEach((p) => {
+            if (p.key && p.value) {
+                authorizationRequestUrl += `&${p.key}=${encodeURIComponent(p.value)}`
+            }
+        });
+    }
 
     if (config.scope) {
         authorizationRequestUrl += "&scope=" + encodeURIComponent(config.scope)

--- a/src/lib/authorizationURL.ts
+++ b/src/lib/authorizationURL.ts
@@ -14,11 +14,11 @@
  *  limitations under the License.
  */
 
-import {LoginOptions} from './loginOptions'
+import {ClientOptions} from './clientOptions'
 import OAuthAgentConfiguration from './oauthAgentConfiguration'
 import {generateHash, generateRandomString} from './pkce'
 
-function getAuthorizationURL(config: OAuthAgentConfiguration, options?: LoginOptions): AuthorizationRequestData {
+function getAuthorizationURL(config: OAuthAgentConfiguration, options?: ClientOptions): AuthorizationRequestData {
     const codeVerifier = generateRandomString()
     const state = generateRandomString()
 

--- a/src/lib/clientOptions.ts
+++ b/src/lib/clientOptions.ts
@@ -1,5 +1,5 @@
 import {ExtraParam} from './extraParams';
 
-export interface LoginOptions {
+export interface ClientOptions {
     extraParams: ExtraParam[];
 }

--- a/src/lib/extraParams.ts
+++ b/src/lib/extraParams.ts
@@ -1,4 +1,4 @@
 export interface ExtraParam {
     key: string;
-    value: any;
+    value: string;
 }

--- a/src/lib/extraParams.ts
+++ b/src/lib/extraParams.ts
@@ -1,4 +1,4 @@
 export interface ExtraParam {
     key: string;
-    value: string;
+    value: any;
 }

--- a/src/lib/extraParams.ts
+++ b/src/lib/extraParams.ts
@@ -1,0 +1,4 @@
+export interface ExtraParam {
+    key: string;
+    value: string;
+}

--- a/src/lib/loginOptions.ts
+++ b/src/lib/loginOptions.ts
@@ -1,0 +1,5 @@
+import {ExtraParam} from './extraParams';
+
+export interface LoginOptions {
+    extraParams: ExtraParam[];
+}

--- a/test/integration/claimsControllerTests.ts
+++ b/test/integration/claimsControllerTests.ts
@@ -3,6 +3,7 @@ import fetch from 'node-fetch';
 import {config} from '../../src/config';
 import {performLogin} from './testUtils'
 
+// Tests to focus on returning ID token details
 describe('ClaimsControllerTests', () => {
 
     const oauthAgentBaseUrl = `http://localhost:${config.port}${config.endpointsPrefix}`

--- a/test/integration/extensibilityTests.ts
+++ b/test/integration/extensibilityTests.ts
@@ -15,7 +15,7 @@ describe('ExtensibilityTests', () => {
                     value: 'login',
                 },
             ],
-        };
+        }
 
         const response = await fetch(
             `${oauthAgentBaseUrl}/login/start`,
@@ -51,7 +51,7 @@ describe('ExtensibilityTests', () => {
                     value: 'fr',
                 },
             ],
-        };
+        }
 
         const response = await fetch(
             `${oauthAgentBaseUrl}/login/start`,
@@ -72,8 +72,8 @@ describe('ExtensibilityTests', () => {
         options.extraParams.forEach((p: any) => {
             expect(authorizationRequestUrl).contains(
                 `${p.key}=${p.value}`,
-                'The extra parameter was not added to the authorization request URL')
-        });
+                'The extra parameters were not added to the authorization request URL')
+        })
     })
 
     it('Starting a login request with the OpenID Connect acr_values parameter should include it in the request URL', async () => {
@@ -82,10 +82,10 @@ describe('ExtensibilityTests', () => {
             extraParams: [
                 {
                     key: 'acr_values',
-                    value: 'acr_values',
+                    value: 'urn:se:curity:authentication:html-form:htmlform1',
                 },
             ],
-        };
+        }
 
         const response = await fetch(
             `${oauthAgentBaseUrl}/login/start`,
@@ -104,8 +104,8 @@ describe('ExtensibilityTests', () => {
         const authorizationRequestUrl = body.authorizationRequestUrl as string
         
         expect(authorizationRequestUrl).contains(
-            `${options.extraParams[0].key}=${options.extraParams[0].value}`,
-            'The extra parameter was not added to the authorization request URL')
+            `${options.extraParams[0].key}=${encodeURIComponent(options.extraParams[0].value)}`,
+            'The acr_values parameter was not added to the authorization request URL')
     })
 
     it('Starting a login request with the OpenID Connect claims parameter should include it in the request URL', async () => {
@@ -115,13 +115,15 @@ describe('ExtensibilityTests', () => {
                 acr: {
                     essential: true,
                     values: [
-                        "acr_1", "acr_2"
+                        "urn:se:curity:authentication:html-form:htmlform1"
                     ]
+                },
+                my_custom_claim: {
+                    essential: true
                 }
             }
-        };
-        const claimsText = JSON.stringify(claims);
-        console.log(claimsText);
+        }
+        const claimsText = JSON.stringify(claims)
 
         const options = {
             extraParams: [
@@ -130,7 +132,7 @@ describe('ExtensibilityTests', () => {
                     value: claimsText,
                 },
             ],
-        };
+        }
 
         const response = await fetch(
             `${oauthAgentBaseUrl}/login/start`,
@@ -150,6 +152,6 @@ describe('ExtensibilityTests', () => {
 
         expect(authorizationRequestUrl).contains(
             `${options.extraParams[0].key}=${encodeURIComponent(options.extraParams[0].value)}`,
-            'The extra parameter was not added to the authorization request URL')
+            'The claims parameter was not correctly added to the authorization request URL')
     })
 })

--- a/test/integration/extensibilityTests.ts
+++ b/test/integration/extensibilityTests.ts
@@ -2,6 +2,7 @@ import {assert, expect} from 'chai'
 import fetch from 'node-fetch'
 import {config} from '../../src/config'
 
+// Tests to focus on extra details the SPA may need to supply at runtime
 describe('ExtensibilityTests', () => {
 
     const oauthAgentBaseUrl = `http://localhost:${config.port}${config.endpointsPrefix}`

--- a/test/integration/extensibilityTests.ts
+++ b/test/integration/extensibilityTests.ts
@@ -7,7 +7,7 @@ describe('ExtensibilityTests', () => {
 
     const oauthAgentBaseUrl = `http://localhost:${config.port}${config.endpointsPrefix}`
 
-    it('Starting a login request with a runtime OpenID Connect parameter should include it in the request URL', async () => {
+    it('Starting a login request with a simple OpenID Connect parameter should include it in the request URL', async () => {
 
         const options = {
             extraParams: [
@@ -41,76 +41,6 @@ describe('ExtensibilityTests', () => {
 
     it('Starting a login request with multiple OpenID Connect parameters should include them in the request URL', async () => {
 
-        const options = {
-            extraParams: [
-                {
-                    key: 'max-age',
-                    value: '3600',
-                },
-                {
-                    key: 'ui_locales',
-                    value: 'fr',
-                },
-            ],
-        }
-
-        const response = await fetch(
-            `${oauthAgentBaseUrl}/login/start`,
-            {
-                method: 'POST',
-                headers: {
-                    origin: config.trustedWebOrigins[0],
-                    'content-type': 'application/json',
-                },
-                body: JSON.stringify(options),
-            },
-        )
-
-        assert.equal(response.status, 200, 'Incorrect HTTP status')
-        const body = await response.json()
-        const authorizationRequestUrl = body.authorizationRequestUrl as string
-        
-        options.extraParams.forEach((p: any) => {
-            expect(authorizationRequestUrl).contains(
-                `${p.key}=${p.value}`,
-                'The extra parameters were not added to the authorization request URL')
-        })
-    })
-
-    it('Starting a login request with the OpenID Connect acr_values parameter should include it in the request URL', async () => {
-
-        const options = {
-            extraParams: [
-                {
-                    key: 'acr_values',
-                    value: 'urn:se:curity:authentication:html-form:htmlform1',
-                },
-            ],
-        }
-
-        const response = await fetch(
-            `${oauthAgentBaseUrl}/login/start`,
-            {
-                method: 'POST',
-                headers: {
-                    origin: config.trustedWebOrigins[0],
-                    'content-type': 'application/json',
-                },
-                body: JSON.stringify(options),
-            },
-        )
-
-        assert.equal(response.status, 200, 'Incorrect HTTP status')
-        const body = await response.json()
-        const authorizationRequestUrl = body.authorizationRequestUrl as string
-        
-        expect(authorizationRequestUrl).contains(
-            `${options.extraParams[0].key}=${encodeURIComponent(options.extraParams[0].value)}`,
-            'The acr_values parameter was not added to the authorization request URL')
-    })
-
-    it('Starting a login request with the OpenID Connect claims parameter should include it in the request URL', async () => {
-
         const claims = {
             id_token: {
                 acr: {
@@ -118,9 +48,6 @@ describe('ExtensibilityTests', () => {
                     values: [
                         "urn:se:curity:authentication:html-form:htmlform1"
                     ]
-                },
-                my_custom_claim: {
-                    essential: true
                 }
             }
         }
@@ -128,6 +55,10 @@ describe('ExtensibilityTests', () => {
 
         const options = {
             extraParams: [
+                {
+                    key: 'ui_locales',
+                    value: 'fr',
+                },
                 {
                     key: 'claims',
                     value: claimsText,
@@ -151,8 +82,10 @@ describe('ExtensibilityTests', () => {
         const body = await response.json()
         const authorizationRequestUrl = body.authorizationRequestUrl as string
 
-        expect(authorizationRequestUrl).contains(
-            `${options.extraParams[0].key}=${encodeURIComponent(options.extraParams[0].value)}`,
-            'The claims parameter was not correctly added to the authorization request URL')
+        options.extraParams.forEach((p: any) => {
+            expect(authorizationRequestUrl).contains(
+                `${p.key}=${encodeURIComponent(p.value)}`,
+                'The extra parameters were not added to the authorization request URL')
+        })
     })
 })

--- a/test/integration/extensibilityTests.ts
+++ b/test/integration/extensibilityTests.ts
@@ -75,4 +75,81 @@ describe('ExtensibilityTests', () => {
                 'The extra parameter was not added to the authorization request URL')
         });
     })
+
+    it('Starting a login request with the OpenID Connect acr_values parameter should include it in the request URL', async () => {
+
+        const options = {
+            extraParams: [
+                {
+                    key: 'acr_values',
+                    value: 'acr_values',
+                },
+            ],
+        };
+
+        const response = await fetch(
+            `${oauthAgentBaseUrl}/login/start`,
+            {
+                method: 'POST',
+                headers: {
+                    origin: config.trustedWebOrigins[0],
+                    'content-type': 'application/json',
+                },
+                body: JSON.stringify(options),
+            },
+        )
+
+        assert.equal(response.status, 200, 'Incorrect HTTP status')
+        const body = await response.json()
+        const authorizationRequestUrl = body.authorizationRequestUrl as string
+        
+        expect(authorizationRequestUrl).contains(
+            `${options.extraParams[0].key}=${options.extraParams[0].value}`,
+            'The extra parameter was not added to the authorization request URL')
+    })
+
+    it('Starting a login request with the OpenID Connect claims parameter should include it in the request URL', async () => {
+
+        const claims = {
+            id_token: {
+                acr: {
+                    essential: true,
+                    values: [
+                        "acr_1", "acr_2"
+                    ]
+                }
+            }
+        };
+        const claimsText = JSON.stringify(claims);
+        console.log(claimsText);
+
+        const options = {
+            extraParams: [
+                {
+                    key: 'claims',
+                    value: claimsText,
+                },
+            ],
+        };
+
+        const response = await fetch(
+            `${oauthAgentBaseUrl}/login/start`,
+            {
+                method: 'POST',
+                headers: {
+                    origin: config.trustedWebOrigins[0],
+                    'content-type': 'application/json',
+                },
+                body: JSON.stringify(options),
+            },
+        )
+
+        assert.equal(response.status, 200, 'Incorrect HTTP status')
+        const body = await response.json()
+        const authorizationRequestUrl = body.authorizationRequestUrl as string
+
+        expect(authorizationRequestUrl).contains(
+            `${options.extraParams[0].key}=${encodeURIComponent(options.extraParams[0].value)}`,
+            'The extra parameter was not added to the authorization request URL')
+    })
 })

--- a/test/integration/extensibilityTests.ts
+++ b/test/integration/extensibilityTests.ts
@@ -1,0 +1,78 @@
+import {assert, expect} from 'chai'
+import fetch from 'node-fetch'
+import {config} from '../../src/config'
+
+describe('ExtensibilityTests', () => {
+
+    const oauthAgentBaseUrl = `http://localhost:${config.port}${config.endpointsPrefix}`
+
+    it('Starting a login request with a runtime OpenID Connect parameter should include it in the request URL', async () => {
+
+        const options = {
+            extraParams: [
+                {
+                    key: 'prompt',
+                    value: 'login',
+                },
+            ],
+        };
+
+        const response = await fetch(
+            `${oauthAgentBaseUrl}/login/start`,
+            {
+                method: 'POST',
+                headers: {
+                    origin: config.trustedWebOrigins[0],
+                    'content-type': 'application/json',
+                },
+                body: JSON.stringify(options),
+            },
+        )
+
+        assert.equal(response.status, 200, 'Incorrect HTTP status')
+        const body = await response.json()
+        const authorizationRequestUrl = body.authorizationRequestUrl as string
+
+        expect(authorizationRequestUrl).contains(
+            `${options.extraParams[0].key}=${options.extraParams[0].value}`,
+            'The extra parameter was not added to the authorization request URL')
+    })
+
+    it('Starting a login request with multiple OpenID Connect parameters should include them in the request URL', async () => {
+
+        const options = {
+            extraParams: [
+                {
+                    key: 'max-age',
+                    value: '3600',
+                },
+                {
+                    key: 'ui_locales',
+                    value: 'fr',
+                },
+            ],
+        };
+
+        const response = await fetch(
+            `${oauthAgentBaseUrl}/login/start`,
+            {
+                method: 'POST',
+                headers: {
+                    origin: config.trustedWebOrigins[0],
+                    'content-type': 'application/json',
+                },
+                body: JSON.stringify(options),
+            },
+        )
+
+        assert.equal(response.status, 200, 'Incorrect HTTP status')
+        const body = await response.json()
+        const authorizationRequestUrl = body.authorizationRequestUrl as string
+        
+        options.extraParams.forEach((p: any) => {
+            expect(authorizationRequestUrl).contains(
+                `${p.key}=${p.value}`,
+                'The extra parameter was not added to the authorization request URL')
+        });
+    })
+})

--- a/test/integration/loginControllerTests.ts
+++ b/test/integration/loginControllerTests.ts
@@ -3,6 +3,7 @@ import fetch from 'node-fetch'
 import {config} from '../../src/config'
 import {performLogin} from './testUtils'
 
+// Tests to focus on the login endpoint
 describe('LoginControllerTests', () => {
 
     const oauthAgentBaseUrl = `http://localhost:${config.port}${config.endpointsPrefix}`

--- a/test/integration/logoutControllerTests.ts
+++ b/test/integration/logoutControllerTests.ts
@@ -3,6 +3,7 @@ import fetch, {RequestInit} from 'node-fetch'
 import {config} from '../../src/config'
 import {performLogin} from './testUtils'
 
+// Tests to focus on the logout endpoint
 describe('LogoutControllerTests', () => {
 
     const oauthAgentBaseUrl = `http://localhost:${config.port}${config.endpointsPrefix}`

--- a/test/integration/refreshTokenControllerTests.ts
+++ b/test/integration/refreshTokenControllerTests.ts
@@ -3,6 +3,7 @@ import fetch, {RequestInit, Response} from 'node-fetch'
 import {config} from '../../src/config'
 import {fetchStubbedResponse, getCookieString, performLogin} from './testUtils'
 
+// Tests to focus on token refresh when access tokens expire
 describe('RefreshTokenControllerTests', () => {
 
     const oauthAgentBaseUrl = `http://localhost:${config.port}${config.endpointsPrefix}`

--- a/test/integration/userInfoControllerTests.ts
+++ b/test/integration/userInfoControllerTests.ts
@@ -3,6 +3,7 @@ import fetch from 'node-fetch';
 import {config} from '../../src/config';
 import {performLogin} from './testUtils'
 
+// Tests to focus on returning user information to the SPA via the user info endpoint
 describe('UserInfoControllerTests', () => {
 
     const oauthAgentBaseUrl = `http://localhost:${config.port}${config.endpointsPrefix}`


### PR DESCRIPTION
Ensure that customers can use common additional options with the token handler pattern:
- Parameters such as prompt / max_age / acr_values / claims

I have done this as a clientOptions object that contains a dictionary of key / value pairs, where both must be strings.
I think this is easiest to reason about and we could potentially use it for other endpoints in future.

Also updated to a yellow badge since we have good testing for this component.
I will add a v1.1.0 tag to this release also, with some notes on changes, and we should do this from now on.