### PR TITLE
Feature/same origin

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -36,6 +36,7 @@ export const config: OAuthAgentConfiguration = {
     cookieNamePrefix: process.env.COOKIE_NAME_PREFIX || 'example',
     encKey: process.env.COOKIE_ENCRYPTION_KEY || '4e4636356d65563e4c73233847503e3b21436e6f7629724950526f4b5e2e4e50',
     trustedWebOrigins: [process.env.TRUSTED_WEB_ORIGIN || 'http://www.example.local'],
+    corsEnabled: process.env.CORS_ENABLED === 'true' || true,
     cookieOptions: {
         httpOnly: true,
         sameSite: true,

--- a/src/config.ts
+++ b/src/config.ts
@@ -36,7 +36,7 @@ export const config: OAuthAgentConfiguration = {
     cookieNamePrefix: process.env.COOKIE_NAME_PREFIX || 'example',
     encKey: process.env.COOKIE_ENCRYPTION_KEY || '4e4636356d65563e4c73233847503e3b21436e6f7629724950526f4b5e2e4e50',
     trustedWebOrigins: [process.env.TRUSTED_WEB_ORIGIN || 'http://www.example.local'],
-    corsEnabled: process.env.CORS_ENABLED === 'true' || true,
+    corsEnabled: process.env.CORS_ENABLED ? process.env.CORS_ENABLED === 'true' : true,
     cookieOptions: {
         httpOnly: true,
         sameSite: true,

--- a/src/controller/ClaimsController.ts
+++ b/src/controller/ClaimsController.ts
@@ -33,6 +33,7 @@ class ClaimsController {
         // Verify the web origin
         const options = new ValidateRequestOptions()
         options.requireCsrfHeader = false;
+        options.requireTrustedOrigin = config.corsEnabled;
         validateExpressRequest(req, options)
 
         const idTokenCookieName = getIDCookieName(config.cookieNamePrefix)

--- a/src/controller/UserInfoController.ts
+++ b/src/controller/UserInfoController.ts
@@ -33,6 +33,7 @@ class UserInfoController {
         // Verify the web origin
         const options = new ValidateRequestOptions()
         options.requireCsrfHeader = false;
+        options.requireTrustedOrigin = config.corsEnabled;
         validateExpressRequest(req, options)
 
         const atCookieName = getATCookieName(config.cookieNamePrefix)

--- a/src/lib/oauthAgentConfiguration.ts
+++ b/src/lib/oauthAgentConfiguration.ts
@@ -41,6 +41,7 @@ export default class OAuthAgentConfiguration {
     public cookieNamePrefix: string
     public encKey: string
     public trustedWebOrigins: string[]
+    public corsEnabled: boolean
     public cookieOptions: CookieSerializeOptions
 
     constructor(
@@ -60,6 +61,7 @@ export default class OAuthAgentConfiguration {
         cookieNamePrefix: string,
         encKey: string,
         trustedWebOrigins: string[],
+        corsEnabled: boolean,
         cookieOptions?: CookieSerializeOptions) {
 
         this.port = port
@@ -76,6 +78,7 @@ export default class OAuthAgentConfiguration {
         this.cookieNamePrefix = cookieNamePrefix ? cookieNamePrefix : "oauthagent"
         this.encKey = encKey
         this.trustedWebOrigins = trustedWebOrigins
+        this.corsEnabled = corsEnabled
         this.cookieOptions = cookieOptions ? cookieOptions : {
             httpOnly: true,
             secure: true,

--- a/src/server.ts
+++ b/src/server.ts
@@ -37,7 +37,10 @@ const corsConfiguration = {
     methods: ['POST']
 }
 
-app.use(cors(corsConfiguration))
+if (config.corsEnabled) {
+    app.use(cors(corsConfiguration))
+}
+
 app.use(cookieParser())
 app.use('*', express.json())
 app.use('*', loggingMiddleware)


### PR DESCRIPTION
In a same domain setup like this, there should be an option for the OAuth Agent to avoid writing any CORS response headers.

Web Static Content: https://www.example.com
Token Handler: https://www.example.com/api

It should also not validate the origin header on GET requests, since it will not be sent by the browser. For POST requests we continue to do so, as a CSRF protection recommended by OWASP.